### PR TITLE
Update CATALOG and OPTION programs, changelog

### DIFF
--- a/sd64/sdsys/GPL.BP/CATALOG
+++ b/sd64/sdsys/GPL.BP/CATALOG
@@ -18,6 +18,8 @@
 * 
 * 
 * START-HISTORY:
+* rev 0.9.0 Jan 25 mab require admin priviliges for global catalog
+*                       and set owner : group to sdsys : sdusers on write
 * 19 Jan 04  0.6.1 SD launch. Earlier history details suppressed.
 * END-HISTORY
 *
@@ -99,6 +101,10 @@ $define CAT_PCODE  3
             if mode and mode # CAT_GLOBAL then stop sysmsg(3021) ;* Incompatible cataloguing modes specified
             option.seen = @true
             mode = CAT_GLOBAL
+            * rev 0.9.0 must be admin for Global
+            if system(27) # 0 then
+              stop sysmsg(2001)  ;* Command requires administrator privileges
+            end 
 
          case keyword = KW$PCODE
             if mode and mode # CAT_PCODE then stop sysmsg(3021) ;* Incompatible cataloguing modes specified
@@ -318,7 +324,10 @@ catalogue.program:
          recordlocku gcat.f, call.name
          mark.mapping gcat.f, off
          write object.code to gcat.f, call.name
-      
+         *
+         * rev 0.9.0 set file ownership
+         set.owner.path =  @sdsys:@ds:'gcat':@ds:call.name 
+         gosub set.owner     
          display sysmsg(3030, call.name) ;* xx added to global catalogue
 
          gosub check.local
@@ -464,6 +473,26 @@ check.global:
    release gcat.f, call.name    ;* Ensure released for all paths
 
    return
+   
+   
+* ======================================================================
+* rev 0.9.0  mab set file ownership    
+* assumes:
+* set.owner.path - file path
+
+set.owner:
+   uid='sdsys'
+   gid='sdusers'
+   chown_parm = uid:@VM:gid:@VM:set.owner.path
+   * print 'set.owner: ':chown_parm
+   result = ospath(chown_parm,OS$CHOWN)
+   if result <= 0 then
+     st = set.owner.path:' err: ':status()
+     display sysmsg(10000,st) ;* Unable change ownership of directory error %1 
+   end
+
+return
+   
 end
 
 * END-CODE

--- a/sd64/sdsys/GPL.BP/OPTION
+++ b/sd64/sdsys/GPL.BP/OPTION
@@ -18,6 +18,10 @@
 * 
 * 
 * START-HISTORY:
+* rev 0.9.0 Jan 25 mab remove pick compatibility options
+*                  note - did not remove references from GPL.BP/INT$KEYS.H, gplsrc/options.h
+*                  as of 0.9.0 these options exist in source, but we have removed the option
+*                  to turn on from this program.
 * 19 Jan 04  0.6.1 SD launch. Earlier history details suppressed.
 * END-HISTORY
 *
@@ -47,22 +51,25 @@ $include int$keys.h
    opt = ''
    opt<-1> = 'UNASS.WARNING|W|3100'
    opt<-1> = '$QUERY.DEBUG||3101'
-   opt<-1> = 'PICK.WILDCARD|P|3102'
-   opt<-1> = 'QUALIFIED.DISPLAY|P|3103'
-   opt<-1> = 'PICK.BREAKPOINT|P|3104'
+   * rev 0.9.0
+   opt<-1> = ''      ;* 'PICK.WILDCARD|P|3102'
+   opt<-1> = ''      ;* 'QUALIFIED.DISPLAY|P|3103'
+   opt<-1> = ''      ;* 'PICK.BREAKPOINT|P|3104'
    opt<-1> = 'WITH.IMPLIES.OR|P|3105'
    opt<-1> = 'DUMP.ON.ERROR||3106'
    opt<-1> = 'DIV.ZERO.WARNING|W|3107'
    opt<-1> = 'NON.NUMERIC.WARNING|W|3108'
    opt<-1> = 'ASSOC.UNASSOC.MV|P|3109'
-   opt<-1> = 'PICK.BREAKPOINT.U|P|3110'
+   * rev 0.9.0
+   opt<-1> = ''      ;* 'PICK.BREAKPOINT.U|P|3110'
    opt<-1> = 'NO.USER.ABORTS||3111'
    opt<-1> = 'RUN.NO.PAGE||3112'
    opt<-1> = 'SHOW.STACK.ON.ERROR||3113'
    opt<-1> = 'CRDB.UPCASE||3114'
    opt<-1> = 'AMPM.UPCASE||3115'
-   opt<-1> = 'PICK.NULL|P|3116'
-   opt<-1> = 'PICK.GRAND.TOTAL|P|3117'
+   * rev 0.9.0
+   opt<-1> = ''      ;* 'PICK.NULL|P|3116'
+   opt<-1> = ''      ;* 'PICK.GRAND.TOTAL|P|3117'
    opt<-1> = 'SUPPRESS.ABORT.MSG||3118'
    opt<-1> = 'DEBUG.REBIND.KEYS||3119'
    opt<-1> = 'ED.NO.QUERY.FD||3120'
@@ -70,11 +77,12 @@ $include int$keys.h
    opt<-1> = 'CHAIN.KEEP.COMMON||3122'
    opt<-1> = 'SELECT.KEEP.CASE||3123'
    opt<-1> = 'CREATE.FILE.UPCASE||3124'
-   opt<-1> = 'PICK.EXPLODE|P|3125'
+   * rev 0.9.0
+   opt<-1> = ''       ;* 'PICK.EXPLODE|P|3125'
    opt<-1> = 'INHERIT||3126'
    opt<-1> = 'QUERY.NO.CASE||3127'
    opt<-1> = 'LOCK.BEEP||3128'
-   opt<-1> = 'PICK.IMPLIED.EQ||3129'
+   opt<-1> = ''       ;* 'PICK.IMPLIED.EQ||3129'
    opt<-1> = 'QUERY.PRIORITY.AND||3130'
    opt<-1> = 'NO.DATE.WRAPPING||3131'
    opt<-1> = 'PROC.A||3132'
@@ -82,9 +90,8 @@ $include int$keys.h
    *         'xxxxxxxxxxxxxxxxxxx'    Option name limit = 19 characters
 
    * Shortcuts
-
    shortcuts = ''
-   shortcuts<1,-1> = 'PICK'             ; shortcuts<2,-1> = 'P'
+*  rev 0.9.0         shortcuts<1,-1> = 'PICK'             ; shortcuts<2,-1> = 'P'
    shortcuts<1,-1> = 'SDBASIC.WARNINGS' ; shortcuts<2,-1> = 'W'
 
 
@@ -193,7 +200,12 @@ display.all:
    descriptions = ''
    n = dcount(desc.msgs, @fm)
    for i = 1 to n
-      descriptions<i> = sysmsg(desc.msgs<i>)
+   * 0.9.0
+      if desc.msgs<i> = '' then
+        descriptions<i> = ''
+      end else
+        descriptions<i> = sysmsg(desc.msgs<i>)
+      end  
    next i
 
    format = maximum(lens(options)) : 'L'
@@ -207,6 +219,11 @@ display.all:
    n = dcount(options, @fm)
    for i = 1 to n
       s = options<i>
+      *rev 0.9.0
+      if s = '' then
+        continue
+      end
+      
       if s[1,1] = '$' and not(is.internal) then
          if not(option.flags[i,1]) then continue
       end

--- a/sd64/sdsys/changelog
+++ b/sd64/sdsys/changelog
@@ -2,6 +2,32 @@ SD, the Multivalue String Database
 
 Change Log:
 -----------------------
+Version 0.9.0
+-------------
+(mab) Convert sd dynamic file blobs prefix from '~' to '%'
+(mab) Turn function "process_file" back on in sdfix. For some reason it was commented out (sdfix did nothing).
+(mab) Modify how group accounts are setup / handled.
+      Group accounts now have their parent directory ownership starting as sdsys : group
+      To access a group account, a user must belong to the linux group of the same name 
+      CREATE-ACCOUNT GROUP <group_name> will create the linux group (if it does not exist).
+      CREATE-ACCOUNT sets the setgid bit on the group_account's parent directory.   This allows the directories / files 
+        to be modified by all the users who are part of the group of the parent directory.
+(mab) Tighten up sdsys file permissions (only allow group to have write access on necessary directories / files).
+(mab) Remove the ability to set "PICK" compatibility options via the OPTION program:
+      PICK.BREAKPOINT    : Off   Pick syntax for BREAK.ON and BREAK.SUP
+      PICK.BREAKPOINT.U  : Off   Handle U breakpoint option in Pick manner
+      PICK.EXPLODE       : Off   Pick style processing of single value item in BY.EXP
+      PICK.GRAND.TOTAL   : Off   GRAND.TOTAL text on same line as values
+      PICK.IMPLIED.EQ    : Off   Implied EQ between field and literal in query
+      PICK.NULL          : Off   Return null for null data in ML, MR and FMT()
+      PICK.WILDCARD      : Off   Allow use of Pick style wildcards in queries
+      QUALIFIED.DISPLAY  : Off   Allow Pick style qualified display clauses
+
+      Note: at this time the source still contains the code to implement these options,
+        but the intent is to not continue supporting "PICK" compatibility.
+(mab) Modify the CATALOG program to:
+        require admin priviliges for global catalog   
+        set owner : group to sdsys : sdusers on write to gcat
 
 Version 0.8.1
 -------------


### PR DESCRIPTION
CATALOG -
require admin priviliges for global catalog
set owner : group to sdsys : sdusers on write to gcat
OPTION -
remove "PICK" compatibility options
Update change log