### PR TITLE
update embedded python  install script

### DIFF
--- a/sd64/examples/python/embedded_python/README.md
+++ b/sd64/examples/python/embedded_python/README.md
@@ -4,11 +4,15 @@ Embedding Python in SD
 
 Steps to build SD with embedded python using the SDEXT function.
 
-If necessary edit:
+If not building with python version 3.12, edit the following to match your python version:
 
   py_Makefile line for correct location of python header files.
 
     PYHDRS   := /usr/include/python3.12
+	
+  py_Makefile line for correct python library.	
+	
+	L_FLAGS    := -Wl,--no-as-needed -lm -lcrypt -ldl -lbsd -L$(LIBSODIUM) -lsodium -lpython3.12  
 
   sdext_py.c line for correct location of python header files.
 

--- a/sd64/examples/python/embedded_python/py_ubuntu-installsd.sh
+++ b/sd64/examples/python/embedded_python/py_ubuntu-installsd.sh
@@ -51,13 +51,9 @@ cp -f examples/python/embedded_python/GPL.BP/* sdsys/GPL.BP
 cp -f examples/python/embedded_python/BP/* sdsys/BP
 
 # backup gpl.src?
-if [ -f  "examples/python/embedded_python/gpl.src.bck" ]; then
-	echo "Appears gpl.src was modified, restoring  "
-	cp -f examples/python/embedded_python/gpl.src.bck  gpl.src
-else
-    echo "Backup up gpl.src  "
-	cp -f gpl.src examples/python/embedded_python/gpl.src.bck  
-fi
+echo "Backup up gpl.src  "
+cp -f gpl.src examples/python/embedded_python/gpl.src.bck  
+
 
 # make sure we compile sdext_py.c
 echo "sdext_py" >> gpl.src
@@ -226,6 +222,10 @@ sudo rm sd64/bin/*.so
 sudo rm sd64/pass1
 sudo rm sd64/pass2
 sudo rm sd64/pcode_bld.log
+
+# restore gpl.src
+echo "Restore gpl.src "
+cp -f sd64/examples/python/embedded_python/gpl.src.bck  sd64/gpl.src
 
 
 # display end of script message

--- a/sd64/examples/python/embedded_python/py_ubuntu-installsd.sh
+++ b/sd64/examples/python/embedded_python/py_ubuntu-installsd.sh
@@ -50,6 +50,15 @@ cp -f examples/python/embedded_python/gplsrc/*  gplsrc
 cp -f examples/python/embedded_python/GPL.BP/* sdsys/GPL.BP
 cp -f examples/python/embedded_python/BP/* sdsys/BP
 
+# backup gpl.src?
+if [ -f  "examples/python/embedded_python/gpl.src.bck" ]; then
+	echo "Appears gpl.src was modified, restoring  "
+	cp -f examples/python/embedded_python/gpl.src.bck  gpl.src
+else
+    echo "Backup up gpl.src  "
+	cp -f gpl.src examples/python/embedded_python/gpl.src.bck  
+fi
+
 # make sure we compile sdext_py.c
 echo "sdext_py" >> gpl.src
 


### PR DESCRIPTION
I updated the python install script. It now saves and restores the gpl.src file. This allows a user to install sd with embedded python, change their mind, remove, then install sd with the "normal" install script. No longer necessary to copy over "clean" sdb64 directory.