### PR TITLE
Bug fixes to BCOMP and op_sort.c

### DIFF
--- a/sd64/gplsrc/op_sort.c
+++ b/sd64/gplsrc/op_sort.c
@@ -17,6 +17,7 @@
  * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  * 
  * START-HISTORY:
+ * rev 0.9.0 Jan 25 mab catch null key id in op_sortdata()
  * 31 Dec 23 SD launch - prior history suppressed
  * END-HISTORY
  *
@@ -554,7 +555,9 @@ void op_sortdata() {
       if (sort_has_data)
         ts_copy(bte->data, strlen(bte->data));
       else
-        ts_copy(bte->key[0], strlen(bte->key[0]));
+/* rev 0.9.0 watch for NULL id */      
+        if (bte->key[0] != NULL)
+          ts_copy(bte->key[0], strlen(bte->key[0]));
       process.status += 1;
 
       /* Locate next item */

--- a/sd64/sdsys/GPL.BP/BCOMP
+++ b/sd64/sdsys/GPL.BP/BCOMP
@@ -29,6 +29,7 @@
 * 06 Aug 24  mab remove PROCREAD/PROCWRITE
 *                correct len(function.args) test in ST.DEFFUN
 *                add SDEXT as internal function
+* rev 0.9.0  Jan 25 mab @FILE.NAME should be allowed as a lvalues per doc
 * END-HISTORY
 *
 *
@@ -290,8 +291,8 @@ $define STACK.MARK 9999         ;* Marks start of sub-expression
 
    * The following @variables, also in the AT.SYSCOM.VARS list above, may be
    * used as lvalues in non-internal mode code.
-
-   at.syscom.lvars = "USER.RETURN.CODE":@fm:"DATE":@fm:"TIME":@fm:"ID"
+* rev 0.9.0 
+   at.syscom.lvars = "USER.RETURN.CODE":@fm:"DATE":@fm:"TIME":@fm:"ID":@fm:"FILE.NAME"
    at.syscom.lvars := @fm:"RECORD":@fm:"SELECTED":@fm:"TRIGGER.RETURN.CODE"
    at.syscom.lvars := @fm:"USER0":@fm:"USER1":@fm:"USER2":@fm:"USER3":@fm:"USER4"
    at.syscom.lvars := @fm:"ANS":@fm:"PIB":@fm:"SIB":@fm:"POB":@fm:"SOB"


### PR DESCRIPTION
BCOMP -
Allow @FILE.NAME as a lvalue (per Doc)

op_sort.c (pcode _SSELCT)-
Prevent segfault if id of file  is "NULL"

Still trying to figure out how you get a file of id "NULL"