### PR TITLE
Usage of semaphore in lock processing

### DIFF
--- a/sd64/gplsrc/sdsem.c
+++ b/sd64/gplsrc/sdsem.c
@@ -97,9 +97,10 @@ void delete_semaphores() {
    Variants on StartExclusive and EndExclusive for use with no shared mem */
 
 void LockSemaphore(int semno) {
-  static struct sembuf sem_lock = {0, -1, 0};
+  static struct sembuf sem_lock = {0, -1, IPC_NOWAIT};
   sem_lock.sem_num = semno;
   while (semop(semid, &sem_lock, 1)) {
+  	RelinquishTimeslice;
   }
 }
 


### PR DESCRIPTION
Semaphores can be used to create exclusive locks, preventing multiple processes from accessing a shared resource at the same time. However, if the IPC_NOWAIT constant is not specified, a process trying to acquire the lock will block and wait if the semaphore is already held by another process. This can lead to unintended synchronization between processes. To avoid this, IPC_NOWAIT should be specified, which will cause the process to return immediately with an error if the lock cannot be acquired.

This fix significantly improves performance when reading files concurrently. The following are test results for 5 million records in Debian:
　　　　　Process count 　　　　　　　　elapsed time (second)
Before
　　　　　1　　　　　　　　　　　　　　11
　　　　　2　　　　　　　　　　　　　　100
　　　　　3　　　　　　　　　　　　　　150
　　　　　4　　　　　　　　　　　　　　200
　　　　　5　　　　　　　　　　　　　　250
　　　　　6　　　　　　　　　　　　　　300

---------------------------------------------------------------------------
After
　　　　　1　　　　　　　　　　　　　　11
　　　　　2　　　　　　　　　　　　　　15
　　　　　3　　　　　　　　　　　　　　25
　　　　　4　　　　　　　　　　　　　　35
　　　　　5　　　　　　　　　　　　　　45
　　　　　6　　　　　　　　　　　　　　55

[The program used for the test](https://github.com/user-attachments/files/18554357/TEST_01.txt)

