### PR TITLE
Hot Fix for BCOMP compiler modes

### DIFF
--- a/sd64/sdsys/GPL.BP/BCOMP
+++ b/sd64/sdsys/GPL.BP/BCOMP
@@ -32,6 +32,7 @@
 * rev 0.9.0  Jan 25 mab @FILE.NAME should be allowed as a lvalues per doc
 * rev 0.9-2  Mar 25 mab add SDPYOBJ python object function
 * rev 1.0-1  mab add back PROCREAD AND PROCWRITE
+* rev 1.0-1  3/17/2026 mab hot fix compiler mode bug 
 * END-HISTORY
 *
 *
@@ -142,6 +143,8 @@ $define M.OPTIONAL.THEN.ELSE   21; *rdm
 * NJS remove hard coded fd hex, use @VM
 mode.names = "UV.LOCATE"
 * 20240728 mab mode.names := @VM:"PICK.ERRMSG"
+* rev 1.0-1 hot fix add empty VM  for PICK.ERRMSG
+mode.names := @VM
 mode.names := @VM:"STRING.LOCATE"
 mode.names := @VM:"COMPOSITE.READNEXT"
 mode.names := @VM:"SELECTV"


### PR DESCRIPTION
Fix compiler mode setting bug.
Bug resulted in modes after PICK.ERRMSG being set off by 1 bit position 

$define M.UV.LOCATE             0
$define M.PICK.ERRMSG           1
$define M.STRING.LOCATE         2
$define M.COMPOSITE.READNEXT    3
$define M.SELECTV               4
$define M.PRCLOSE.DEFAULT.0     5
$define M.FOR.STORE.BEFORE.TEST 6
$define M.CASE.SENSITIVE        7
$define M.PMATRIX               8
$define M.PICK.JUMP.RANGE       9
$define M.PICK.READ            10
$define M.OPTIONAL.FINAL.END   11
$define M.PICK.SUBSTR          12
$define M.COMPAT.APPEND        13
$define M.PICK.ENTER           14
$define M.TRAP.UNUSED          15
$define M.PICK.SUBSTR.ASSIGN   16
$define M.UNASSIGNED.COMMON    17
** Begin New Modes **
$define M.HEADING.NO.EJECT     18
$define M.NO.ECHO.DATA         19
$define M.NO.CASE.INVERT       20
$define M.OPTIONAL.THEN.ELSE   21; *rdm